### PR TITLE
Fix filter activation on nginx >= 1.10.1

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 ngx_addon_name=ngx_http_length_hiding_filter_module
 
 if test -n "$ngx_module_link"; then
-    ngx_module_type=HTTP
+    ngx_module_type=HTTP_FILTER
     ngx_module_name=ngx_http_length_hiding_filter_module
     ngx_module_srcs="$ngx_addon_dir/ngx_http_length_hiding_filter_module.c"
     . auto/module


### PR DESCRIPTION
The nginx module type should be `HTTP_FILTER` instead of `HTTP`.
